### PR TITLE
onCleared not emitting

### DIFF
--- a/src/lib/components/searchfilter/searchfilter.component.ts
+++ b/src/lib/components/searchfilter/searchfilter.component.ts
@@ -67,6 +67,9 @@ export class SearchFilterCtrl implements ng.IComponentController {
 
   public clearSearch(): void {
     this.searchStr = '';
+    if (angular.isFunction(this.onCleared)) {
+      this.onCleared();
+    }
   }
 
   public focusInput(): void {


### PR DESCRIPTION
Using upgraded 'md-searchfilter' in Angular component. 

Currently, 'onCleared' is not emitting event.

Definition of upgraded 'md-searchfilter' directive in Angular:

```
export class MdSearchFilterDirective extends UpgradeComponent { 
 
@Input() clearAriaText: string;  
@Input() filters;  
@Output() setFilterFn: EventEmitter<any>;  
@Input() placeholderText: string;  
@Output() searchItemFn: EventEmitter<any>;  
@Input() hideCount: string;  
@Input() clear: any;  
// tslint:disable-next-line  
@Output() onCleared: EventEmitter<any>;  
@Input() searchPlaceholderText: string;

constructor(elementRef: ElementRef, injector: Injector) {    super('mdSearchfilter', elementRef, injector);  }
}
```

My code:
```
//.html code
<md-searchfilter          
(searchItemFn)="searchGroup($event)"                
[searchPlaceholderText]="searchPlaceholderTextLabel"           
(onCleared)="clearSearch($event)">        
</md-searchfilter>

//component.ts code
public clearSearch($event) {    
   console.log('clearSearch: called: ', $event);  
}
```

I have put a console.log in 'clearSearch()' function, but the function is not called when clearing the search input (user clicks on 'X' in search box to cancel the search).